### PR TITLE
Update rcon.py

### DIFF
--- a/aiorcon/rcon.py
+++ b/aiorcon/rcon.py
@@ -24,7 +24,7 @@ class RCON:
             if rcon._auto_reconnect_attempts and not rcon._closing:
                 rcon._reconnecting = asyncio.ensure_future(rcon._reconnect(), loop=rcon._loop)
 
-        rcon.protocol_factory = lambda: RCONProtocol(password=password, loop=loop,
+        rcon.protocol_factory = lambda: RCONProtocol(password=password, loop=rcon._loop,
                                                      connection_lost_cb=connection_lost,
                                                      multiple_packet=multiple_packet, timeout=timeout)
         rcon.protocol = None


### PR DESCRIPTION
Initialise the protocol factory with rcon._loop, rather than the passed loop variable. If the user does not pass a loop in the initialisation, loop will still be null however rcon._loop is initialised with the asyncio.get_event_loop. Therefore, use the rcon._loop in the protocol factory's initialisation.